### PR TITLE
Irish vat numbers can have other characters at the end

### DIFF
--- a/lib/europe/vat/format.rb
+++ b/lib/europe/vat/format.rb
@@ -21,7 +21,7 @@ module Europe
         FR: /^FR[A-Z0-9][A-Z0-9] \d{9}$/,
         HR: /^HR\d{11}$/,
         HU: /^HU\d{8}$/,
-        IE: /^IE\d[A-Z0-9\+\*|\d]\d{5}([A-Z]|WI)$/,
+        IE: /^IE(\d[A-Z]\d{5}[A-Z]|\d{7}[A-Z]{2})$/,
         IT: /^IT\d{11}$/,
         LT: /^LT(\d{9}|\d{12})$/,
         LU: /^LU\d{8}$/,


### PR DESCRIPTION
for example Slack: IE3336483DH

See https://ec.europa.eu/taxation_customs/vies/#/faq Q11

The examples given are: IE9S99999L & IE9999999LL
Description: 1 block of 8 characters or 1 block of 9 characters